### PR TITLE
feat(node): add markers for initial connection attempt/timeout

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -221,6 +221,9 @@ impl Client {
                 self.peers_added += 1;
             }
             NetworkEvent::PeerRemoved(_) | NetworkEvent::UnverifiedRecord(_) => {}
+            // These events are only applicable to the node
+            NetworkEvent::AttemptingNetworkConnection => {},
+            NetworkEvent::NetworkConnectionTimingOut => {},
         }
 
         Ok(())

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -351,6 +351,12 @@ impl SwarmDriver {
     /// Dials the given multiaddress. If address contains a peer ID, simultaneous
     /// dials to that peer are prevented.
     pub(crate) fn dial(&mut self, mut addr: Multiaddr) -> Result<(), DialError> {
+        self.num_dials += 1;
+        trace!("Total number of dial events: {}", self.num_dials);
+        if self.num_dials == 1 {
+            self.send_event(NetworkEvent::AttemptingNetworkConnection);
+        }
+
         debug!(%addr, "Dialing manually");
 
         let peer_id = multiaddr_pop_p2p(&mut addr);

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -96,6 +96,10 @@ pub enum MsgResponder {
 #[derive(Debug)]
 /// Events forwarded by the underlying Network; to be used by the upper layers
 pub enum NetworkEvent {
+    /// Dialing initial peers and attempting to connect to the network
+    AttemptingNetworkConnection,
+    /// Failed to dial initial peers and connect to the network
+    NetworkConnectionTimingOut,
     /// Incoming `Request` from a peer
     RequestReceived {
         /// Request
@@ -289,7 +293,14 @@ impl SwarmDriver {
             SwarmEvent::Dialing {
                 peer_id,
                 connection_id,
-            } => trace!("Dialing {peer_id:?} on {connection_id:?}"),
+            } => {
+                self.num_dials += 1;
+                trace!("Total number of dial events: {}", self.num_dials);
+                if self.num_dials == 1 {
+                    self.send_event(NetworkEvent::AttemptingNetworkConnection);
+                }
+                trace!("Dialing {peer_id:?} on {connection_id:?}");
+            }
 
             SwarmEvent::Behaviour(NodeEvent::Autonat(event)) => match event {
                 autonat::Event::InboundProbe(e) => debug!("AutoNAT inbound probe: {e:?}"),

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -112,6 +112,7 @@ pub struct SwarmDriver {
     local: bool,
     /// A list of the most recent peers we have dialed ourselves.
     dialed_peers: CircularVec<PeerId>,
+    num_dials: usize,
     is_client: bool,
 }
 
@@ -392,6 +393,7 @@ impl SwarmDriver {
             // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
+            num_dials: 0,
             is_client,
         };
 

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -156,6 +156,12 @@ impl Node {
         initial_join_underway_or_done: Arc<AtomicBool>,
     ) {
         match event {
+            NetworkEvent::AttemptingNetworkConnection => {
+                self.events_channel.broadcast(NodeEvent::AttemptingNetworkConnection);
+            }
+            NetworkEvent::NetworkConnectionTimingOut => {
+                self.events_channel.broadcast(NodeEvent::NetworkConnectionTimingOut);
+            }
             NetworkEvent::RequestReceived { req, channel } => {
                 trace!("RequestReceived: {req:?}");
                 self.handle_request(req, channel).await;

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -43,6 +43,10 @@ impl NodeEventsChannel {
 /// Type of events broadcasted by the node to the public API.
 #[derive(Clone, Debug)]
 pub enum NodeEvent {
+    /// Dialing an initial peer and attempting to connect to the network
+    AttemptingNetworkConnection,
+    /// Attempt to dial initial peers and connect to network is timing out after a period of time
+    NetworkConnectionTimingOut,
     /// The node has been connected to the network
     ConnectedToNetwork,
     /// A Chunk has been stored in local storage

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -17,6 +17,12 @@ use strum::Display;
 /// Changing these log markers is a breaking change.
 #[derive(Debug, Clone, Display)]
 pub enum Marker<'a> {
+    /// Dialing an initial peer and attempting to connect to the network
+    AttemptingNetworkConnection,
+
+    /// Attempt to dial initial peers and connect to the network is timing out after a period of time
+    NetworkConnectionTimingOut,
+
     /// The node has started
     NodeConnectedToNetwork,
 


### PR DESCRIPTION
Added AttemptingNetworkConnection marker for attempt to dial initial peers and NetworkConnectionTimingOut marker if timing out.